### PR TITLE
Make field not required

### DIFF
--- a/power-the-polls-form/src/components/power-the-polls-form/power-the-polls-form.tsx
+++ b/power-the-polls-form/src/components/power-the-polls-form/power-the-polls-form.tsx
@@ -216,7 +216,6 @@ export class PowerThePollsForm {
                      {partnerField}
                      <input
                         type="text"
-                        required
                         name="user_partner_field"
                      />
                   </label>


### PR DESCRIPTION
Makes this field not required - at this point AFL-CIO is the only partner that has the extra field. We can add an additional requirement if other partners need a required field.